### PR TITLE
Permettre d'installer l'environnement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+web/*
+crash.log
+.sass-cache/*
+tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,5 @@ gem 'builder'
 gem 'rainpress'
 gem 'nanoc-cachebuster'
 
+#  documentation, extension compiling, testing, and deployment
+gem 'echoe', '~> 4.6', '>= 4.6.6'

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,6 @@ gem 'nanoc-cachebuster'
 
 #  documentation, extension compiling, testing, and deployment
 gem 'echoe', '~> 4.6', '>= 4.6.6'
+
+# javascript
+gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     json (1.8.3)
     json_pure (2.0.1)
     kramdown (1.8.0)
+    libv8 (3.16.14.15)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -80,11 +81,15 @@ GEM
     rb-readline (0.5.3)
     rdoc (4.2.2)
       json (~> 1.4)
+    ref (2.0.0)
     rubyforge (2.0.4)
       json_pure (>= 1.1.7)
     sass (3.4.16)
     shellany (0.0.1)
     slop (3.6.0)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
@@ -106,6 +111,7 @@ DEPENDENCIES
   nanoc-cachebuster
   rainpress
   rb-readline (~> 0.5.2)
+  therubyracer
   uglifier (>= 1.0.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     adsf (1.2.0)
       rack (>= 1.0.0)
+    allison (2.0.3)
     autoprefixer-rails (5.2.1.1)
       execjs
       json
@@ -27,6 +28,11 @@ GEM
       sass (>= 3.2, < 3.5)
     cri (2.7.0)
       colored (~> 1.2)
+    echoe (4.6.6)
+      allison (>= 2.0.3)
+      rake (>= 0.9.2)
+      rdoc (>= 2.5.11)
+      rubyforge (>= 2.0.4)
     execjs (2.5.2)
     ffi (1.9.10)
     font-awesome-sass (4.3.2.1)
@@ -45,6 +51,7 @@ GEM
       guard (~> 2.8)
       nanoc (~> 3.6)
     json (1.8.3)
+    json_pure (2.0.1)
     kramdown (1.8.0)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
@@ -66,10 +73,15 @@ GEM
       slop (~> 3.4)
     rack (1.6.4)
     rainpress (1.0)
+    rake (11.2.2)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rb-readline (0.5.3)
+    rdoc (4.2.2)
+      json (~> 1.4)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
     sass (3.4.16)
     shellany (0.0.1)
     slop (3.6.0)
@@ -86,6 +98,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.3)
   builder
   compass (~> 1.0.3)
+  echoe (~> 4.6, >= 4.6.6)
   font-awesome-sass (~> 4.3.0)
   guard-nanoc (~> 1.0.3)
   kramdown
@@ -94,3 +107,6 @@ DEPENDENCIES
   rainpress
   rb-readline (~> 0.5.2)
   uglifier (>= 1.0.3)
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
Car le bundle install ne fonctionnait pas.

```
chaneguejean-tristan@m00025907:~/Sites/laprimaire/LaPrimaire$ bundle install
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Installing rack 1.6.4
Installing execjs 2.5.2
Using json 1.8.3
Installing sass 3.4.16
Installing builder 3.2.2
Installing chunky_png 1.3.4
Installing coderay 1.1.0
Installing colored 1.2
Installing multi_json 1.11.2
Installing rb-fsevent 0.9.5
Installing ffi 1.9.10 with native extensions
Installing formatador 0.2.5
Installing lumberjack 1.0.9
Installing nenv 0.2.0
Installing shellany 0.0.1
Installing method_source 0.8.2
Installing slop 3.6.0
Installing thor 0.19.1
Installing kramdown 1.8.0
Your Gemfile.lock is corrupt. The following gem is missing from the DEPENDENCIES
section: 'echoe'
```
